### PR TITLE
动态配色支持、UI 整体修复与改进

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         minSdk = 24
         targetSdk = 34
         // 版本号为x.y.z则versionCode为x*1000000+y*10000+z*100+debug版本号(开发需要时迭代, 两位数)
-        versionCode = 4_04_017
+        versionCode = 4_04_018
         versionName = "0.4.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         minSdk = 24
         targetSdk = 34
         // 版本号为x.y.z则versionCode为x*1000000+y*10000+z*100+debug版本号(开发需要时迭代, 两位数)
-        versionCode = 4_04_018
+        versionCode = 4_04_019
         versionName = "0.4.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         minSdk = 24
         targetSdk = 34
         // 版本号为x.y.z则versionCode为x*1000000+y*10000+z*100+debug版本号(开发需要时迭代, 两位数)
-        versionCode = 4_04_019
+        versionCode = 4_04_020
         versionName = "0.4.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         minSdk = 24
         targetSdk = 34
         // 版本号为x.y.z则versionCode为x*1000000+y*10000+z*100+debug版本号(开发需要时迭代, 两位数)
-        versionCode = 4_04_020
+        versionCode = 4_04_021
         versionName = "0.4.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/debug/res/values-zh-rCN/strings.xml
+++ b/app/src/debug/res/values-zh-rCN/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="settings_statistics_desc">*Debug 构建不可用</string>
+</resources>

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name" translatable="false">[DEBUG] LightNovelReader</string>
+    <string name="settings_statistics_desc">*Unavailable for debug builds</string>
 </resources>

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/MainActivity.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/MainActivity.kt
@@ -53,6 +53,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         var appLocale by mutableStateOf("${Locale.current.platformLocale.language}-${Locale.current.platformLocale.variant}")
         var darkMode by mutableStateOf("FollowSystem")
+        var dynamicColor by mutableStateOf(false)
         installSplashScreen()
         var statisticsEnabled by mutableStateOf(true)
         workManager.enqueueUniquePeriodicWork(
@@ -98,17 +99,25 @@ class MainActivity : ComponentActivity() {
                 it?.let { isUsingVolumeKeyFlip = it }
             }
         }
-        if (Build.VERSION.SDK_INT >= 33) { /* Android 13 + */
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) { /* Android 13 + */
             if (ContextCompat.checkSelfPermission(this, POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
                 ActivityCompat.requestPermissions(
                     this, arrayOf(POST_NOTIFICATIONS), 0
                 )
             }
         }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            coroutineScope.launch(Dispatchers.IO) {
+                userDataRepository.booleanUserData(UserDataPath.Settings.Display.DynamicColors.path).getFlow().collect {
+                    dynamicColor = it ?: false
+                }
+            }
+        }
         setContent {
             LightNovelReaderTheme(
                 darkMode = darkMode,
-                appLocale = appLocale
+                appLocale = appLocale,
+                isDynamicColor = dynamicColor
             ) {
                 LightNovelReaderApp()
             }

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/data/userdata/UserDataPath.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/data/userdata/UserDataPath.kt
@@ -34,6 +34,7 @@ sealed class UserDataPath(
         }
         data object Display: UserDataPath("display", Settings) {
             data object DarkMode : UserDataPath("dark_mode", Display)
+            data object DynamicColors : UserDataPath("dynamic_color", Display)
             data object AppLocale : UserDataPath("app_locale", Display)
         }
         data object Reader : UserDataPath("reader", Settings) {

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/theme/Themes.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/theme/Themes.kt
@@ -21,24 +21,25 @@ import indi.dmzz_yyhyy.lightnovelreader.utils.LocaleUtil
 
 @Composable
 fun LightNovelReaderTheme(
-    isDarkTheme: Boolean = isSystemInDarkTheme(),
     darkMode: String,
-    isDynamicColor: Boolean = false,
+    isDynamicColor: Boolean = true,
     appLocale: String,
     content: @Composable () -> Unit
 ) {
     val context = LocalContext.current
+    val appDarkTheme = when (darkMode) {
+        "Enabled" -> true
+        "Disabled" -> false
+        "FollowSystem" -> isSystemInDarkTheme()
+        else -> isSystemInDarkTheme()
+    }
     val colorScheme =
         if (isDynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
-            if ((darkMode == "FollowSystem" && isDarkTheme) || (darkMode == "Enabled"))
-                dynamicDarkColorScheme(context)
-            else
-                dynamicLightColorScheme(context)
+            if (appDarkTheme) dynamicDarkColorScheme(context)
+            else dynamicLightColorScheme(context)
         else
-            if ((darkMode == "FollowSystem" && isDarkTheme) || (darkMode == "Enabled"))
-                darkColorScheme()
-            else
-                lightColorScheme()
+            if (appDarkTheme) darkColorScheme()
+            else lightColorScheme()
 
     if (!LocalInspectionMode.current) {
         val view = LocalView.current
@@ -53,11 +54,11 @@ fun LightNovelReaderTheme(
 
             val controller = WindowCompat.getInsetsController(window, view)
             window.statusBarColor = Color.Transparent.toArgb()
-            controller.isAppearanceLightStatusBars = !isDarkTheme
+            controller.isAppearanceLightStatusBars = !appDarkTheme
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
                 window.navigationBarColor = Color.Transparent.toArgb()
-                controller.isAppearanceLightNavigationBars = !isDarkTheme
+                controller.isAppearanceLightNavigationBars = !appDarkTheme
             }
         }
     }

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/book/detail/DetailScreen.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/book/detail/DetailScreen.kt
@@ -434,9 +434,7 @@ private fun Description(description: String) {
             onTextLayout = {
                 isNeedExpand = it.hasVisualOverflow || isNeedExpand
             },
-            style = MaterialTheme.typography.bodyMedium.copy(
-                fontWeight = FontWeight.W400
-            ),
+            style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurface,
             overflow = TextOverflow.Ellipsis
         )
@@ -454,7 +452,7 @@ private fun Description(description: String) {
                         tint = MaterialTheme.colorScheme.primary
                     )
                     Text(
-                        text = "展开",
+                        text = if (expandSummaryText) "收起" else "展开",
                         color = MaterialTheme.colorScheme.primary
                     )
                 }

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/book/detail/DetailScreen.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/book/detail/DetailScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -45,6 +46,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.max
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import indi.dmzz_yyhyy.lightnovelreader.R
@@ -495,19 +497,21 @@ private fun VolumeItem(
             Box(
                 modifier = Modifier
                     .clickable { onClickChapter(it.id) }
-                    .height(48.dp)
+                    .wrapContentHeight()
                     .fillMaxWidth()
                     .padding(horizontal = 4.dp, vertical = 8.dp),
             ) {
                 Row(
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Text(
-                        modifier = Modifier.padding(start = 8.dp),
+                        modifier = Modifier.padding(horizontal = 8.dp),
                         text = it.title,
                         style = MaterialTheme.typography.bodyMedium,
-                        fontSize = 16.sp,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                        fontSize = 15.sp,
                         fontWeight =
                         if (readCompletedChapterIds.contains(it.id))
                             FontWeight.W400

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/components/SettingsEntry.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/components/SettingsEntry.kt
@@ -171,7 +171,7 @@ fun SettingsMenuEntry(
                             lineHeight = 14.sp,
                             color = MaterialTheme.colorScheme.onSurface
                         )
-                        Text(
+                        AnimatedText(
                             text = options.get(selectedOptionKey).name,
                             fontSize = 13.sp,
                             lineHeight = 14.sp,

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/components/SettingsEntry.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/components/SettingsEntry.kt
@@ -2,16 +2,12 @@ package indi.dmzz_yyhyy.lightnovelreader.ui.components
 
 import android.content.Intent
 import android.net.Uri
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -22,41 +18,30 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.geometry.RoundRect
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.unit.times
 import androidx.core.content.ContextCompat.startActivity
 import indi.dmzz_yyhyy.lightnovelreader.ui.home.settings.data.MenuOptions
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.text.DecimalFormat
 import kotlin.math.roundToInt
 
-/* NOTE
-* SettingsSwitchEntry and SettingsSliderEntry renamed and moved from ContentScreen.kt
-*/
 @Composable
 fun SettingsSwitchEntry(
     title: String,
     description: String,
     checked: Boolean,
     onCheckedChange: (Boolean) -> Unit,
+    disabled: Boolean = false
 ) {
     FilledCard(
         modifier = Modifier
@@ -66,8 +51,8 @@ fun SettingsSwitchEntry(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable { onCheckedChange(!checked) }
-                .padding(18.dp, 10.dp, 20.dp, 12.dp),
+                .then(if (disabled) Modifier.clickable {} else Modifier.clickable { onCheckedChange(!checked) })
+            .padding(18.dp, 10.dp, 20.dp, 12.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Column(
@@ -89,16 +74,18 @@ fun SettingsSwitchEntry(
                     fontWeight = FontWeight.W500,
                     fontSize = 13.sp,
                     lineHeight = 14.sp,
-                    color = MaterialTheme.colorScheme.secondary
+                    color = MaterialTheme.colorScheme.onSurface
                 )
             }
             Switch(
                 checked = checked,
-                onCheckedChange = onCheckedChange
+                enabled = !disabled,
+                onCheckedChange = if (disabled) null else onCheckedChange
             )
         }
     }
 }
+
 
 @Composable
 fun SettingsSliderEntry(

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/bookshelf/home/BookshelfHomeScreen.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/bookshelf/home/BookshelfHomeScreen.kt
@@ -121,22 +121,21 @@ fun BookshelfHomeScreen(
     ) {
         if (uiState.bookshelfList.size > 4) {
             ScrollableTabRow(
+                containerColor = animatedBackgroundColor,
                 selectedTabIndex = uiState.selectedTabIndex,
                 edgePadding = 16.dp,
                 indicator = { tabPositions ->
-                    if (tabPositions.isNotEmpty()) {
-                        SecondaryIndicator(
-                            modifier = Modifier
-                                .tabIndicatorOffset(tabPositions[uiState.selectedTabIndex])
-                                .height(4.dp)
-                                .clip(RoundedCornerShape(topStart = 3.dp, topEnd = 3.dp))
-                                .background(MaterialTheme.colorScheme.secondary),
-                            color = MaterialTheme.colorScheme.primary,
-                        )
-                    }
+                    SecondaryIndicator(
+                        modifier = Modifier
+                            .tabIndicatorOffset(tabPositions[uiState.selectedTabIndex])
+                            .height(4.dp)
+                            .clip(RoundedCornerShape(topStart = 3.dp, topEnd = 3.dp))
+                            .background(MaterialTheme.colorScheme.secondary),
+                        color = MaterialTheme.colorScheme.primary,
+                    )
                 },
             ) {
-                uiState.bookshelfList.forEachIndexed { _, bookshelf ->
+                uiState.bookshelfList.forEach { bookshelf ->
                     Tab(
                         selected = uiState.selectedBookshelfId == bookshelf.id,
                         onClick = { if (!uiState.selectMode) changePage(bookshelf.id) },
@@ -151,12 +150,15 @@ fun BookshelfHomeScreen(
             }
         }
         else {
-            PrimaryTabRow(selectedTabIndex = uiState.selectedTabIndex) {
-                uiState.bookshelfList.forEachIndexed { _, bookshelf ->
+            PrimaryTabRow(
+                selectedTabIndex = uiState.selectedTabIndex,
+                containerColor = animatedBackgroundColor
+            ) {
+                uiState.bookshelfList.forEach { bookshelf ->
                     Tab(
                         selected = uiState.selectedBookshelfId == bookshelf.id,
                         onClick = { if (!uiState.selectMode) changePage(bookshelf.id) },
-                        text = { Text(text = bookshelf.name, maxLines = 1, overflow = TextOverflow.Ellipsis) }
+                        text = { Text(text = bookshelf.name, maxLines = 1, overflow = TextOverflow.Ellipsis) },
                     )
                 }
             }

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/bookshelf/home/BookshelfHomeScreen.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/bookshelf/home/BookshelfHomeScreen.kt
@@ -372,7 +372,7 @@ fun BookRow(
             overflow = TextOverflow.Ellipsis
         )
         Text(
-            text = bookInformation.description,
+            text = bookInformation.description.trim(),
             style = descriptionTextStyle,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/bookshelf/home/BookshelfHomeScreen.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/bookshelf/home/BookshelfHomeScreen.kt
@@ -612,7 +612,13 @@ fun TopBar(
             }
         },
         actions = {
-            IconButton(if (!selectMode) onClickCreat else onClickSelectAll) {
+            IconButton(
+                if (!selectMode) {
+                    scrollBehavior.state.heightOffset = 0f
+                    onClickCreat
+                }
+                else onClickSelectAll
+            ) {
                 Icon(
                     painter = if (!selectMode) painterResource(R.drawable.library_add_24px) else painterResource(R.drawable.select_all_24px),
                     contentDescription = if (!selectMode) "create" else "select all"

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/bookshelf/home/BookshelfHomeScreen.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/bookshelf/home/BookshelfHomeScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MediumTopAppBar
+import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.ScrollableTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
@@ -118,7 +119,7 @@ fun BookshelfHomeScreen(
                 drawRect(animatedBackgroundColor)
             }
     ) {
-        if (uiState.bookshelfList.size >= 4) {
+        if (uiState.bookshelfList.size > 4) {
             ScrollableTabRow(
                 selectedTabIndex = uiState.selectedTabIndex,
                 edgePadding = 16.dp,
@@ -150,34 +151,12 @@ fun BookshelfHomeScreen(
             }
         }
         else {
-            TabRow(
-                selectedTabIndex = uiState.selectedTabIndex,
-                containerColor = Color.Transparent,
-                contentColor = MaterialTheme.colorScheme.primary,
-                indicator = { tabPositions ->
-                    if (tabPositions.isNotEmpty())
-                        SecondaryIndicator(
-                            modifier = Modifier
-                                .tabIndicatorOffset(tabPositions[uiState.selectedTabIndex])
-                                .height(4.dp)
-                                .clip(RoundedCornerShape(topStart = 3.dp, topEnd = 3.dp))
-                                .background(MaterialTheme.colorScheme.secondary),
-                            color = MaterialTheme.colorScheme.primary,
-                        )
-                }
-            ) {
+            PrimaryTabRow(selectedTabIndex = uiState.selectedTabIndex) {
                 uiState.bookshelfList.forEachIndexed { _, bookshelf ->
                     Tab(
                         selected = uiState.selectedBookshelfId == bookshelf.id,
                         onClick = { if (!uiState.selectMode) changePage(bookshelf.id) },
-                        text = {
-                            Text(
-                                text = bookshelf.name,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis
-                            )
-                        },
-                        modifier = Modifier.padding(horizontal = 8.dp)
+                        text = { Text(text = bookshelf.name, maxLines = 1, overflow = TextOverflow.Ellipsis) }
                     )
                 }
             }

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/bookshelf/home/BookshelfHomeScreen.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/bookshelf/home/BookshelfHomeScreen.kt
@@ -300,7 +300,7 @@ fun CollapseGroupTitle(
         )
         IconButton(onClickExpand) {
             Icon(
-                modifier = Modifier.rotate(if (expanded) 180f else 0f),
+                modifier = Modifier.rotate(if (expanded) 0f else 180f),
                 painter = painterResource(R.drawable.keyboard_arrow_up_24px),
                 contentDescription = "expand"
             )

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/exploration/Exploration.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/exploration/Exploration.kt
@@ -188,7 +188,6 @@ fun ExplorationBookCard(
                     style = MaterialTheme.typography.labelLarge,
                     fontWeight = FontWeight.W700,
                     fontSize = 16.sp,
-                    lineHeight = 18.sp,
                     maxLines = 2
                 )
                 IconButton(
@@ -216,7 +215,7 @@ fun ExplorationBookCard(
                     bookInformation.wordCount,
                     if (bookInformation.isComplete) stringResource(R.string.book_completed)
                     else stringResource(R.string.book_ongoing),
-                    bookInformation.description
+                    bookInformation.description.trim()
                 ),
                 style = MaterialTheme.typography.labelLarge,
                 fontSize = 13.sp,

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/reading/ReadingScreen.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/reading/ReadingScreen.kt
@@ -207,7 +207,7 @@ private fun SimpleBookCard(book: ReadingBook, onClicked: () -> Unit) {
                     maxLines = 1
                 )
                 Text(
-                    text = book.description,
+                    text = book.description.trim(),
                     style = MaterialTheme.typography.titleMedium.copy(
                         fontSize = 14.sp,
                         fontWeight = FontWeight.W500
@@ -261,7 +261,7 @@ private fun LargeBookCard(
                 )
                 Text(
                     modifier = Modifier.fillMaxWidth().height(66.dp),
-                    text = book.description,
+                    text = book.description.trim(),
                     style = MaterialTheme.typography.titleMedium.copy(
                         fontWeight = FontWeight.W500
                     ),

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/settings/SettingsScreen.kt
@@ -92,7 +92,8 @@ fun SettingsScreen(
             content = { DisplaySettingsList(
                 state = state,
                 onLocaleChanged = viewModel::onAppLocaleChanged,
-                onDarkModeChanged = viewModel::onDarkModeChanged
+                onDarkModeChanged = viewModel::onDarkModeChanged,
+                onDynamicColorChanged = viewModel::onDynamicColorChanged
             ) }
         )
         /*SettingsCard(

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/settings/SettingsViewModel.kt
@@ -19,6 +19,7 @@ interface SettingsState {
     val statisticsEnabled: Boolean
     val updateChannelKey: String
     val darkModeKey: String
+    val dynamicColorsEnabled: Boolean
     val appLocaleKey: String
 }
 
@@ -27,6 +28,7 @@ class MutableSettingsState: SettingsState {
     override var statisticsEnabled: Boolean by mutableStateOf(true)
     override var updateChannelKey: String by mutableStateOf("Development")
     override var darkModeKey: String by mutableStateOf("FollowSystem")
+    override var dynamicColorsEnabled: Boolean by mutableStateOf(true)
     override var appLocaleKey: String by mutableStateOf("zh-CN")
 }
 
@@ -40,6 +42,7 @@ class SettingsViewModel @Inject constructor(
     private val appLocaleKey = userDataRepository.stringUserData(UserDataPath.Settings.Display.AppLocale.path)
     private val statisticsUserData = userDataRepository.booleanUserData(UserDataPath.Settings.App.Statistics.path)
     private val darkModeKey = userDataRepository.stringUserData(UserDataPath.Settings.Display.DarkMode.path)
+    private val dynamicColorsKey = userDataRepository.booleanUserData(UserDataPath.Settings.Display.DynamicColors.path)
     private val updateChannelKey = userDataRepository.stringUserData(UserDataPath.Settings.App.UpdateChannel.path)
     val settingsState: SettingsState = _settingsState
 
@@ -49,11 +52,13 @@ class SettingsViewModel @Inject constructor(
             val statistics = statisticsUserData.getOrDefault(true)
             val darkModeKey = darkModeKey.getOrDefault("FollowSystem")
             val appLocaleKey = appLocaleKey.getOrDefault("zh-CN")
+            val dynamicColors = dynamicColorsKey.getOrDefault(false)
             val updateChannelKey = updateChannelKey.getOrDefault("Development")
             _settingsState.checkUpdateEnabled = checkUpdate
             _settingsState.statisticsEnabled = statistics
             _settingsState.darkModeKey = darkModeKey
             _settingsState.appLocaleKey = appLocaleKey
+            _settingsState.dynamicColorsEnabled = dynamicColors
             _settingsState.updateChannelKey = updateChannelKey
         }
     }
@@ -83,6 +88,13 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             userDataRepository.stringUserData(UserDataPath.Settings.Display.DarkMode.path).set(value)
             _settingsState.darkModeKey = value
+        }
+    }
+
+    fun onDynamicColorChanged(value: Boolean) {
+        viewModelScope.launch(Dispatchers.IO) {
+            userDataRepository.booleanUserData(UserDataPath.Settings.Display.DynamicColors.path).set(value)
+            _settingsState.dynamicColorsEnabled = value
         }
     }
 

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/settings/list/AboutSettingsList.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/settings/list/AboutSettingsList.kt
@@ -68,8 +68,9 @@ fun AboutSettingsList(
             SettingsSwitchEntry(
                 title = stringResource(R.string.settings_statistics),
                 description = stringResource(R.string.settings_statistics_desc),
-                checked = state.statisticsEnabled,
-                onCheckedChange = onStatisticsChanged
+                checked = if (BuildConfig.DEBUG) false else state.statisticsEnabled,
+                onCheckedChange = onStatisticsChanged,
+                disabled = BuildConfig.DEBUG
             )
         }
     }

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/settings/list/DisplaySettingsList.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/settings/list/DisplaySettingsList.kt
@@ -1,5 +1,6 @@
 package indi.dmzz_yyhyy.lightnovelreader.ui.home.settings.list
 
+import android.os.Build
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -10,8 +11,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.google.android.material.color.utilities.DynamicColor
+import indi.dmzz_yyhyy.lightnovelreader.BuildConfig
 import indi.dmzz_yyhyy.lightnovelreader.R
 import indi.dmzz_yyhyy.lightnovelreader.ui.components.SettingsMenuEntry
+import indi.dmzz_yyhyy.lightnovelreader.ui.components.SettingsSwitchEntry
 import indi.dmzz_yyhyy.lightnovelreader.ui.home.settings.SettingsState
 import indi.dmzz_yyhyy.lightnovelreader.ui.home.settings.data.MenuOptions
 
@@ -19,7 +23,8 @@ import indi.dmzz_yyhyy.lightnovelreader.ui.home.settings.data.MenuOptions
 fun DisplaySettingsList(
     state: SettingsState,
     onDarkModeChanged: (String) -> Unit,
-    onLocaleChanged: (String) -> Unit
+    onLocaleChanged: (String) -> Unit,
+    onDynamicColorChanged: (Boolean) -> Unit
 ) {
     Box(
         modifier = Modifier.padding(top = 0.dp, end = 14.dp, start = 14.dp, bottom = 14.dp)
@@ -34,6 +39,13 @@ fun DisplaySettingsList(
                 options = MenuOptions.DarkModeOptions,
                 selectedOptionKey = state.darkModeKey,
                 onOptionChange = onDarkModeChanged
+            )
+            SettingsSwitchEntry(
+                title = stringResource(R.string.settings_dynamic_colors),
+                description = stringResource(R.string.settings_dynamic_colors_desc),
+                checked = state.dynamicColorsEnabled,
+                onCheckedChange = onDynamicColorChanged,
+                disabled = Build.VERSION.SDK_INT < Build.VERSION_CODES.S
             )
             SettingsMenuEntry(
                 title = stringResource(R.string.settings_characters_variant),

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -45,7 +45,7 @@
     <string name="settings_dynamic_colors">系统动态配色</string>
     <string name="settings_dynamic_colors_desc">从系统主题应用动态配色 (Android 12 +)</string>
     <string name="settings_characters_variant">汉字变体</string>
-    <string name="settings_characters_variant_desc">使用指定语言的汉字变体</string>
+    <string name="settings_characters_variant_desc">（实验性）使用指定语言的汉字变体，需要系统字体支持</string>
     <string name="about_settings">关于</string>
     <string name="settings_app_build">构建</string>
     <string name="settings_github_repo">GitHub 仓库</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -42,6 +42,8 @@
     <string name="display_settings">显示</string>
     <string name="settings_dark_theme">深色主题</string>
     <string name="settings_dark_theme_desc">选择是否启用深色主题</string>
+    <string name="settings_dynamic_colors">系统动态配色</string>
+    <string name="settings_dynamic_colors_desc">从系统主题应用动态配色 (Android 12 +)</string>
     <string name="settings_characters_variant">汉字变体</string>
     <string name="settings_characters_variant_desc">使用指定语言的汉字变体</string>
     <string name="about_settings">关于</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,7 +42,9 @@
     <string name="settings_get_updates_desc">Check and get the latest version</string>
     <string name="display_settings">Display</string>
     <string name="settings_dark_theme">Dark Theme</string>
-    <string name="settings_dark_theme_desc">Enable dark theme</string>
+    <string name="settings_dark_theme_desc">Apply dynamic colors from system (requires Android 12 +)</string>
+    <string name="settings_dynamic_colors">Dynamic Colors</string>
+    <string name="settings_dynamic_colors_desc">Enable dark theme</string>
     <string name="settings_characters_variant">Chinese Characters Variant</string>
     <string name="settings_characters_variant_desc">Specify Chinese characters variants for other languages</string>
     <string name="about_settings">About</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,11 +42,11 @@
     <string name="settings_get_updates_desc">Check and get the latest version</string>
     <string name="display_settings">Display</string>
     <string name="settings_dark_theme">Dark Theme</string>
-    <string name="settings_dark_theme_desc">Apply dynamic colors from system (requires Android 12 +)</string>
+    <string name="settings_dark_theme_desc">Override application dark theme</string>
     <string name="settings_dynamic_colors">Dynamic Colors</string>
-    <string name="settings_dynamic_colors_desc">Enable dark theme</string>
+    <string name="settings_dynamic_colors_desc">Apply dynamic colors from system (requires Android 12 +)</string>
     <string name="settings_characters_variant">Chinese Characters Variant</string>
-    <string name="settings_characters_variant_desc">Specify Chinese characters variants for other languages</string>
+    <string name="settings_characters_variant_desc">(Experimental) Specify Chinese characters variants for other languages</string>
     <string name="about_settings">About</string>
     <string name="settings_app_build">Build</string>
     <string name="settings_github_repo">GitHub Repo</string>


### PR DESCRIPTION
Fixes in this PR:
- 修正书架页Tab宽度问题，并对4个以上的Tab项使用滚动
- 修复书架页Tab一处潜在的闪退
- 优化一些页面的书本描述文本前显示空白的问题
- 详情页章节名称字体回滚，并允许显示至多2行标题
- 开关设置项新增禁用选项
- 新增列表设置项已选项目文本动画
- 修复书架分组折叠图标错误的方向、新增折叠文本
- 新增 Material You 动态配色（Android 12+）
- 优化App主题的应用逻辑
- 详情页介绍文本使用默认字重
- 修正AppBar折叠时点击编辑书架页面会显示错误的AppBar高度