### PR TITLE
AppBar 闪退修复

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         minSdk = 24
         targetSdk = 34
         // 版本号为x.y.z则versionCode为x*1000000+y*10000+z*100+debug版本号(开发需要时迭代, 两位数)
-        versionCode = 4_04_023
+        versionCode = 4_04_024
         versionName = "0.4.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/reading/ReadingScreen.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/reading/ReadingScreen.kt
@@ -28,8 +28,8 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MediumTopAppBar
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -69,10 +69,10 @@ fun ReadingScreen(
     LifecycleEventEffect(Lifecycle.Event.ON_CREATE) {
         viewModel.update()
     }
-    LifecycleEventEffect(Lifecycle.Event.ON_START) {
-        topBar { _, pinnedScrollBehavior ->
-            TopBar(pinnedScrollBehavior)
-        }
+    topBar { enterAlwaysScrollBehavior, _ ->
+        TopBar(
+            scrollBehavior = enterAlwaysScrollBehavior,
+        )
     }
     LazyColumn(
         modifier = Modifier.fillMaxSize().padding(start = 16.dp, end = 16.dp),
@@ -151,7 +151,7 @@ fun ReadingScreen(
 private fun TopBar(
     scrollBehavior: TopAppBarScrollBehavior
 ) {
-    TopAppBar(
+    MediumTopAppBar(
         title = {
                 Text(
                     text = stringResource(R.string.nav_reading),


### PR DESCRIPTION
我们已经确定 AppBar 的滚动行为可能是导致 #97 的问题之一，为了修复该问题并确保整体 UI 统一性，这个PR：
- 将「阅读中」页面的 AppBar 调整为 MediumTopAppBar
- 修复了「阅读中」页面有概率无法滚动的问题
- 修复影响大量用户的 AppBar 导致的应用闪退问题
- closes #97 