### PR TITLE
支持禁用手势返回

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,7 +19,7 @@ android {
         minSdk = 24
         targetSdk = 36
         // 版本号为x.y.z则versionCode为x*1000000+y*10000+z*1000+debug版本号(开发需要时迭代, 三位数)
-        versionCode = 1_01_01_005
+        versionCode = 1_01_01_007
         versionName = "1.1.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/data/userdata/UserDataPath.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/data/userdata/UserDataPath.kt
@@ -45,6 +45,7 @@ sealed class UserDataPath(
         data object BackgroundColor : UserDataPath("backgroundColor", Reader)
         data object BackgroundImageUri : UserDataPath("backgroundImageUri", Reader)
         data object BackgroundDarkImageUri : UserDataPath("backgroundDarkImageUri", Reader)
+        data object BlockBackMode : UserDataPath("blockBackMode", Reader)
     }
     data object ReadingBooks : UserDataPath("reading_books")
     data object Search: UserDataPath("search") {

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/data/userdata/UserDataPath.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/data/userdata/UserDataPath.kt
@@ -45,7 +45,7 @@ sealed class UserDataPath(
         data object BackgroundColor : UserDataPath("backgroundColor", Reader)
         data object BackgroundImageUri : UserDataPath("backgroundImageUri", Reader)
         data object BackgroundDarkImageUri : UserDataPath("backgroundDarkImageUri", Reader)
-        data object BlockBackMode : UserDataPath("blockBackMode", Reader)
+        data object BackBlockMode : UserDataPath("backBlockMode", Reader)
     }
     data object ReadingBooks : UserDataPath("reading_books")
     data object Search: UserDataPath("search") {

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/book/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/book/reader/ReaderScreen.kt
@@ -8,6 +8,7 @@ import android.util.Log
 import android.view.View
 import android.view.WindowManager
 import android.widget.Toast
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.LocalActivity
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
@@ -55,6 +56,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -87,6 +89,7 @@ import indi.dmzz_yyhyy.lightnovelreader.ui.book.reader.content.ContentComponent
 import indi.dmzz_yyhyy.lightnovelreader.ui.components.AnimatedText
 import indi.dmzz_yyhyy.lightnovelreader.ui.components.AnimatedTextLine
 import indi.dmzz_yyhyy.lightnovelreader.ui.components.RollingNumber
+import indi.dmzz_yyhyy.lightnovelreader.ui.home.settings.data.MenuOptions
 import indi.dmzz_yyhyy.lightnovelreader.utils.rememberReaderBackgroundPainter
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -110,6 +113,31 @@ fun ReaderScreen(
 ) {
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
     var isImmersive by remember { mutableStateOf(false) }
+    val context = LocalContext.current
+    val backBlockMode = settingState.backBlockMode
+    var lastBackPressTime: Long by remember { mutableLongStateOf(0) }
+
+    BackHandler {
+        when (backBlockMode) {
+            MenuOptions.ReaderBackBlockMode.None -> {
+                onClickBackButton()
+            }
+            MenuOptions.ReaderBackBlockMode.DoublePress -> {
+                val now = System.currentTimeMillis()
+                if (now - lastBackPressTime < 1500) {
+                    onClickBackButton()
+                } else {
+                    lastBackPressTime = now
+                    Toast.makeText(
+                        context,
+                        context.getString(R.string.reader_back_press_again),
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+            }
+            MenuOptions.ReaderBackBlockMode.FullyBlocked -> { }
+        }
+    }
     DisposableEffect(Unit) {
         onDispose {
             isImmersive = false

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/book/reader/ReaderSettingsScreen.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/book/reader/ReaderSettingsScreen.kt
@@ -291,6 +291,17 @@ fun LazyListScope.ActionPage(settingState: SettingState) {
             booleanUserData = settingState.isUsingFlipPageUserData,
         )
     }
+    item {
+        SettingsMenuEntry(
+            modifier = Modifier.animateItem(),
+            iconRes = R.drawable.block_24px,
+            title = stringResource(R.string.settings_reader_back_block_mode),
+            description = stringResource(R.string.settings_reader_back_block_mode_desc),
+            options = MenuOptions.ReaderBackBlockMode,
+            selectedOptionKey = settingState.backBlockMode,
+            stringUserData = settingState.backBlockModeUserData
+        )
+    }
     if (settingState.isUsingFlipPage) {
         item {
             SettingsSwitchEntry(

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/book/reader/SettingState.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/book/reader/SettingState.kt
@@ -51,6 +51,7 @@ class SettingState(
     val dynamicColorsKeyUserData = userDataRepository.booleanUserData(UserDataPath.Settings.Display.DynamicColors.path)
     val lightThemeNameUserData = userDataRepository.stringUserData(UserDataPath.Settings.Display.LightThemeName.path)
     val darkThemeNameUserData = userDataRepository.stringUserData(UserDataPath.Settings.Display.DarkThemeName.path)
+    val blockBackModeUserData = userDataRepository.stringUserData(UserDataPath.Reader.BlockBackMode.path)
 
     val fontSize by fontSizeUserData.safeAsState(15f)
     val fontLineHeight by fontLineHeightUserData.safeAsState(7f)
@@ -86,4 +87,5 @@ class SettingState(
     val dynamicColorsKey by dynamicColorsKeyUserData.asState(false)
     val lightThemeName by lightThemeNameUserData.safeAsState("light_default")
     val darkThemeName by darkThemeNameUserData.safeAsState("dark_default")
+    val blockBackMode by blockBackModeUserData.safeAsState("none")
 }

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/book/reader/SettingState.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/book/reader/SettingState.kt
@@ -51,7 +51,7 @@ class SettingState(
     val dynamicColorsKeyUserData = userDataRepository.booleanUserData(UserDataPath.Settings.Display.DynamicColors.path)
     val lightThemeNameUserData = userDataRepository.stringUserData(UserDataPath.Settings.Display.LightThemeName.path)
     val darkThemeNameUserData = userDataRepository.stringUserData(UserDataPath.Settings.Display.DarkThemeName.path)
-    val blockBackModeUserData = userDataRepository.stringUserData(UserDataPath.Reader.BlockBackMode.path)
+    val backBlockModeUserData = userDataRepository.stringUserData(UserDataPath.Reader.BackBlockMode.path)
 
     val fontSize by fontSizeUserData.safeAsState(15f)
     val fontLineHeight by fontLineHeightUserData.safeAsState(7f)
@@ -87,5 +87,5 @@ class SettingState(
     val dynamicColorsKey by dynamicColorsKeyUserData.asState(false)
     val lightThemeName by lightThemeNameUserData.safeAsState("light_default")
     val darkThemeName by darkThemeNameUserData.safeAsState("dark_default")
-    val blockBackMode by blockBackModeUserData.safeAsState("none")
+    val backBlockMode by backBlockModeUserData.safeAsState("none")
 }

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/settings/data/MenuOptions.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/settings/data/MenuOptions.kt
@@ -135,9 +135,9 @@ sealed class MenuOptions {
         val Immersed = option("immersed", R.string.key_reader_indicator_battery_display_mode_immersed)
     }
 
-    data object ReaderBlockBackMode: MenuOptions() {
-        val none = option("none", R.string.key_reader_back_block_mode_none)
-        val button = option("double_press", R.string.key_reader_back_block_mode_double_press)
-        val blocked = option("blocked", R.string.key_reader_back_block_mode_blocked)
+    data object ReaderBackBlockMode: MenuOptions() {
+        val None = option("none", R.string.key_reader_back_block_mode_none)
+        val DoublePress = option("double_press", R.string.key_reader_back_block_mode_double_press)
+        val FullyBlocked = option("blocked", R.string.key_reader_back_block_mode_blocked)
     }
 }

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/settings/data/MenuOptions.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/settings/data/MenuOptions.kt
@@ -134,4 +134,10 @@ sealed class MenuOptions {
         val Classic = option("classic", R.string.key_reader_indicator_battery_display_mode_classic)
         val Immersed = option("immersed", R.string.key_reader_indicator_battery_display_mode_immersed)
     }
+
+    data object ReaderBlockBackMode: MenuOptions() {
+        val none = option("none", R.string.key_reader_back_block_mode_none)
+        val button = option("double_press", R.string.key_reader_back_block_mode_double_press)
+        val blocked = option("blocked", R.string.key_reader_back_block_mode_blocked)
+    }
 }

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -31,6 +31,7 @@
     <string name="export_and_share">Поделиться</string>
     <string name="choose_light_bg">Выбрать светлый фон</string>
     <string name="choose_dark_bg">Выбрать тёмный фон</string>
+    <string name="reader_back_press_again">Нажмите назад ещё раз, чтобы выйти из чтения</string>
 
     <!-- Подсказки -->
     <string name="nothing_here">Здесь ничего нет</string>
@@ -71,12 +72,15 @@
     <string name="settings_reader_page_mode_desc">Переключение между прокруткой и перелистыванием страниц.</string>
     <string name="settings_reader_volume_key_control">Управление кнопками громкости</string>
     <string name="settings_reader_volume_key_control_desc">Используйте кнопку "+" для перехода на предыдущую страницу и "-" для следующей.</string>
+    <string name="settings_reader_volume_key_interval">Интервал непрерывного перелистывания клавишей</string>
     <string name="settings_reader_t2tp">Касание для перелистывания</string>
     <string name="settings_reader_t2tp_desc">Включите перелистывание по нажатию и смените жест вызова меню на вертикальный свайп.</string>
     <string name="settings_reader_page_turn_anim">Анимация перелистывания</string>
     <string name="settings_reader_page_turn_anim_desc">Настройте анимацию перелистывания. При выборе «Нет» включается быстрое перелистывание.</string>
     <string name="settings_reader_quick_chapter_switch">Быстрая смена главы</string>
     <string name="settings_reader_quick_chapter_switch_desc">Автоматически переключать главы при перелистывании на начале или конце главы.</string>
+    <string name="settings_reader_back_block_mode">Блокировка возврата</string>
+    <string name="settings_reader_back_block_mode_desc">Предотвращает случайный выход из режима чтения. При полной блокировке вернуться можно только с помощью кнопки в левом верхнем углу</string>
     <string name="settings_reader_auto_margin">Автоматическая регулировка полей</string>
     <string name="settings_reader_auto_margin_desc">Автоматически определять и настраивать поля экрана. Отключите для ручной настройки.</string>
     <string name="settings_reader_top_margin">Верхнее поле</string>

--- a/app/src/main/res/values-zh-rCN/key_strings.xml
+++ b/app/src/main/res/values-zh-rCN/key_strings.xml
@@ -35,5 +35,9 @@
     <string name="key_reader_indicator_battery_display_mode_hidden">隐藏</string>
     <string name="key_reader_indicator_battery_display_mode_classic">经典</string>
     <string name="key_reader_indicator_battery_display_mode_immersed">沉浸</string>
+    <!-- Reader Back Block Mode -->
+    <string name="key_reader_back_block_mode_none">无</string>
+    <string name="key_reader_back_block_mode_double_press">双击</string>
+    <string name="key_reader_back_block_mode_blocked">完全阻止</string>
 
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -30,6 +30,8 @@
     <string name="export_and_share">导出并分享</string>
     <string name="choose_light_bg">选择浅色背景</string>
     <string name="choose_dark_bg">选择深色背景</string>
+    <string name="reader_back_press_again">再次点击返回以退出阅读</string>
+
     <!-- Hints -->
     <string name="nothing_here">没有内容</string>
     <string name="nothing_here_desc_reading">阅读一些书本之后，它们将显示在此处</string>
@@ -75,6 +77,8 @@
     <string name="settings_reader_page_turn_anim_desc">设置翻页动画，选择“无”时启用快速翻页</string>
     <string name="settings_reader_quick_chapter_switch">快速章节切换</string>
     <string name="settings_reader_quick_chapter_switch_desc">允许在章节的开头或结尾翻页时自动切换章节</string>
+    <string name="settings_reader_back_block_mode">阻止返回</string>
+    <string name="settings_reader_back_block_mode_desc">在阅读器中阻止误触发返回。如果完全阻止，则只能使用左上角的返回按钮</string>
     <string name="settings_reader_auto_margin">自动边距调整</string>
     <string name="settings_reader_auto_margin_desc">自动检测并调整屏幕边距，关闭以手动设置各边距值</string>
     <string name="settings_reader_top_margin">顶部边距</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -30,6 +30,8 @@
     <string name="export_and_share">匯出並分享</string>
     <string name="choose_light_bg">選擇淺色背景</string>
     <string name="choose_dark_bg">選擇深色背景</string>
+    <string name="reader_back_press_again">再次點擊返回以退出閱讀</string>
+
     <!-- Hints -->
     <string name="nothing_here">沒有內容</string>
     <string name="nothing_here_desc_reading">閱讀一些書本後，它們會顯示在這裡</string>
@@ -75,6 +77,8 @@
     <string name="settings_reader_page_turn_anim_desc">設定翻頁動畫，選擇「無」時啟用快速翻頁</string>
     <string name="settings_reader_quick_chapter_switch">快速章節切換</string>
     <string name="settings_reader_quick_chapter_switch_desc">允許在章節的開頭或結尾翻頁時自動切換章節</string>
+    <string name="settings_reader_back_block_mode">阻止返回</string>
+    <string name="settings_reader_back_block_mode_desc">在閱讀器中防止誤觸返回。如果完全阻止，只能使用左上角的返回按鈕</string>
     <string name="settings_reader_auto_margin">自動邊距調整</string>
     <string name="settings_reader_auto_margin_desc">自動偵測並調整螢幕邊距，關閉以手動設定各邊距值</string>
     <string name="settings_reader_top_margin">頂部邊距</string>

--- a/app/src/main/res/values/key_strings.xml
+++ b/app/src/main/res/values/key_strings.xml
@@ -53,4 +53,8 @@
     <string name="key_reader_indicator_battery_display_mode_hidden">Hidden</string>
     <string name="key_reader_indicator_battery_display_mode_classic">Classic</string>
     <string name="key_reader_indicator_battery_display_mode_immersed">Immersed</string>
+    <!-- Reader Back Block Mode -->
+    <string name="key_reader_back_block_mode_none">None</string>
+    <string name="key_reader_back_block_mode_double_press">Double Press</string>
+    <string name="key_reader_back_block_mode_blocked">Fully Blocked</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="export_and_share">Share</string>
     <string name="choose_light_bg">Choose Light Background</string>
     <string name="choose_dark_bg">Choose Dark Background</string>
+    <string name="reader_back_press_again">Press back again to exit reading</string>
 
     <!-- Hints -->
     <string name="nothing_here">Nothing Here</string>
@@ -79,6 +80,8 @@
     <string name="settings_reader_page_turn_anim_desc">Configure the page turn animation. When set to "None," fast page turning is enabled</string>
     <string name="settings_reader_quick_chapter_switch">Quick Chapter Switch</string>
     <string name="settings_reader_quick_chapter_switch_desc">Automatically switch chapters when turning pages at the beginning or end of a chapter</string>
+    <string name="settings_reader_back_block_mode">Back Prevention</string>
+    <string name="settings_reader_back_block_mode_desc">Prevent accidental back actions in the reader. If fully blocked, only the top-left back button can be used</string>
     <string name="settings_reader_auto_margin">Auto Margin Adjustment</string>
     <string name="settings_reader_auto_margin_desc">Automatically detect and adjust screen margins. Disable this to set margins manually</string>
     <string name="settings_reader_top_margin">Top Margin</string>


### PR DESCRIPTION
为阅读器增加禁用手势返回功能。resolved #172 
可选：无（默认）、双击、完全阻止。
如果完全阻止，则只能通过左上角的返回按钮返回。

- 添加返回阻止模式 ac8ba8275c1b3463750f078db8cf9f0bd6d72b25
- 阅读器返回阻止功能 78337955fed2b5f90bf3dd622bfbc0bc84d9f201