### PR TITLE
尝试修复[探索.xx]页面的数组越界异常,还有一个优化

### DIFF
--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/exploration/expanded/ExpandedPageViewModel.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/exploration/expanded/ExpandedPageViewModel.kt
@@ -40,13 +40,27 @@ class ExpandedPageViewModel @Inject constructor(
                 _uiState.filters.clear()
                 _uiState.filters.addAll(explorationExpandedPageDataSource.getFilters())
                 explorationExpandedPageDataSource.getResultFlow().collect { result ->
-                    _uiState.bookList.clear()
-                    _uiState.bookList.addAll(
-                        result.map {
+
+                    if (result.isEmpty()) {
+                        explorationExpandedPageDataSource.loadMore() }
+                    else{
+                        val resultList = result.map {
                             textProcessingRepository.processBookInformation { it }
                         }
-                    )
-                    if (result.isEmpty()) { explorationExpandedPageDataSource.loadMore() }
+                        val differentElements = resultList.filterNot {
+                            _uiState.bookList.contains(it)
+                        }
+                        _uiState.bookList.addAll(differentElements)
+
+                    }
+
+//                    _uiState.bookList.clear()
+//                    _uiState.bookList.addAll(
+//                        result.map {
+//                            textProcessingRepository.processBookInformation { it }
+//                        }
+//                    )
+//                    if (result.isEmpty()) { explorationExpandedPageDataSource.loadMore() }
                 }
             }
         }


### PR DESCRIPTION

优化原因:发现触发加载更多时,会滚动到`_uiState.bookList`的索引为0的位置,个人推测是 `_uiState.bookList.clear()`导致的问题

优化改成,比较2个list,取出不同的元素, 直接加旧list后面