### PR TITLE
修复#321问题，缓存重进详情页，没有进度条问题

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,7 +24,7 @@ android {
         minSdk = 24
         targetSdk = 36
         // 版本号为x.y.z则versionCode为x*1000000+y*10000+z*1000+debug版本号(开发需要时迭代, 三位数)
-        versionCode = 1_02_00_037
+        versionCode = 1_02_00_038
         versionName = "1.2.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/data/book/BookRepository.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/data/book/BookRepository.kt
@@ -11,6 +11,7 @@ import indi.dmzz_yyhyy.lightnovelreader.data.local.LocalBookDataSource
 import indi.dmzz_yyhyy.lightnovelreader.data.text.TextProcessingRepository
 import indi.dmzz_yyhyy.lightnovelreader.data.web.WebBookDataSourceProvider
 import indi.dmzz_yyhyy.lightnovelreader.data.work.CacheBookWork
+import indi.dmzz_yyhyy.lightnovelreader.data.work.cacheBookUniqueWorkName
 import io.nightfish.lightnovelreader.api.book.BookInformation
 import io.nightfish.lightnovelreader.api.book.BookRepositoryApi
 import io.nightfish.lightnovelreader.api.book.BookVolumes
@@ -201,7 +202,7 @@ class BookRepository @Inject constructor(
             )
             .build()
         workManager.enqueueUniqueWork(
-            bookId,
+            cacheBookUniqueWorkName(bookId),
             ExistingWorkPolicy.KEEP,
             workRequest
         )

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/data/work/CacheBookWork.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/data/work/CacheBookWork.kt
@@ -14,6 +14,10 @@ import indi.dmzz_yyhyy.lightnovelreader.data.download.MutableDownloadItem
 import indi.dmzz_yyhyy.lightnovelreader.data.local.LocalBookDataSource
 import indi.dmzz_yyhyy.lightnovelreader.data.web.WebBookDataSourceProvider
 
+private const val CACHE_BOOK_UNIQUE_WORK_PREFIX = "cache:"
+
+fun cacheBookUniqueWorkName(bookId: String): String = CACHE_BOOK_UNIQUE_WORK_PREFIX + bookId
+
 @HiltWorker
 class CacheBookWork @AssistedInject constructor(
     @Assisted appContext: Context,

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/data/work/ExportDataWork.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/data/work/ExportDataWork.kt
@@ -18,6 +18,10 @@ import kotlinx.serialization.cbor.Cbor
 import kotlinx.serialization.encodeToByteArray
 import java.io.FileOutputStream
 
+private const val EXPORT_BOOK_UNIQUE_WORK_PREFIX = "export:"
+
+fun exportBookUniqueWorkName(bookId: String): String = EXPORT_BOOK_UNIQUE_WORK_PREFIX + bookId
+
 @HiltWorker
 class ExportDataWork @AssistedInject constructor(
     @Assisted private val appContext: Context,

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/book/detail/DetailViewModel.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/book/detail/DetailViewModel.kt
@@ -19,6 +19,8 @@ import indi.dmzz_yyhyy.lightnovelreader.data.bookshelf.BookshelfRepository
 import indi.dmzz_yyhyy.lightnovelreader.data.download.DownloadProgressRepository
 import indi.dmzz_yyhyy.lightnovelreader.data.download.DownloadType
 import indi.dmzz_yyhyy.lightnovelreader.data.work.ExportBookToEPUBWork
+import indi.dmzz_yyhyy.lightnovelreader.data.work.cacheBookUniqueWorkName
+import indi.dmzz_yyhyy.lightnovelreader.data.work.exportBookUniqueWorkName
 import io.nightfish.lightnovelreader.api.web.WebDataSourcePriority
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -33,6 +35,10 @@ class DetailViewModel @Inject constructor(
     private val workManager: WorkManager
 ) : ViewModel() {
     private val _uiState = MutableDetailUiState()
+    private var currentCacheState: WorkInfo.State? = null
+    private var lastNotifiedCacheState: WorkInfo.State? = null
+    var cacheSnackbarState: WorkInfo.State? by mutableStateOf(null)
+        private set
     var exportSettings = ExportSettings()
     var navController: NavController? = null
     val uiState: DetailUiState = _uiState
@@ -77,24 +83,67 @@ class DetailViewModel @Inject constructor(
         }
         viewModelScope.launch(Dispatchers.IO) {
             downloadProgressRepository.downloadItemIdListFlow.collect { downloadItemList ->
-                _uiState.downloadItem = downloadItemList.findLast { it.bookId == _uiState.bookInformation.id && it.type == DownloadType.CACHE }
+                _uiState.downloadItem = downloadItemList.findLast { it.bookId == bookId && it.type == DownloadType.CACHE }
             }
         }
+        startCacheWorkMonitor(bookId)
+    }
+    fun cacheBook(bookId: String){
+        if( currentCacheState == WorkInfo.State.RUNNING ||
+            currentCacheState == WorkInfo.State.ENQUEUED ||
+            currentCacheState == WorkInfo.State.BLOCKED
+            ){
+            return
+        }
+        bookRepository.cacheBook(bookId)
     }
 
-    fun cacheBook(bookId: String): Flow<WorkInfo?> {
-        val work = bookRepository.cacheBook(bookId)
-        val isCachedFlow = bookRepository.isCacheBookWorkFlow(work.id)
+    fun startCacheWorkMonitor(bookId:String){
         viewModelScope.launch(Dispatchers.IO) {
-            isCachedFlow.collect { workInfo ->
-                if (workInfo?.state == WorkInfo.State.SUCCEEDED) {
-                    _uiState.isCached = bookRepository.getIsBookCached(bookId)
+            workManager.getWorkInfosForUniqueWorkFlow(cacheBookUniqueWorkName(bookId)).collect { workInfos ->
+                val states = workInfos.map{it.state}.toSet()
+                val state = listOf(
+                    WorkInfo.State.RUNNING,
+                    WorkInfo.State.ENQUEUED,
+                    WorkInfo.State.BLOCKED,
+                    WorkInfo.State.SUCCEEDED,
+                    WorkInfo.State.CANCELLED,
+                    WorkInfo.State.FAILED,
+                ).firstOrNull{it in states }
+                val previousCacheState = currentCacheState
+                currentCacheState = state
+                when(state){
+                    WorkInfo.State.RUNNING ->{
+                        notifyCacheState(state)
+                    }
+                    WorkInfo.State.ENQUEUED,
+                    WorkInfo.State.BLOCKED -> {
+                        notifyCacheState(state)
+                    }
+                    WorkInfo.State.SUCCEEDED -> {
+                        _uiState.isCached = bookRepository.getIsBookCached(bookId)
+                        if( previousCacheState == WorkInfo.State.RUNNING ||
+                            previousCacheState == WorkInfo.State.ENQUEUED ||
+                            previousCacheState == WorkInfo.State.BLOCKED
+                        ){
+                            notifyCacheState(state)
+                        }
+                    }
+                    WorkInfo.State.CANCELLED,
+                    WorkInfo.State.FAILED -> {
+                        notifyCacheState(state)
+                    }
+                    else -> Unit
                 }
             }
         }
-        return isCachedFlow
     }
 
+    private fun notifyCacheState(state: WorkInfo.State) {
+        if(lastNotifiedCacheState == state) return
+        lastNotifiedCacheState = state
+        cacheSnackbarState = state
+    }
     fun onClickTag(tag: String) {
         if (navController == null) return
         bookRepository.progressBookTagClick(tag, navController!!)
@@ -115,7 +164,7 @@ class DetailViewModel @Inject constructor(
             )
             .build()
         workManager.enqueueUniqueWork(
-            bookId,
+            exportBookUniqueWorkName(bookId),
             ExistingWorkPolicy.KEEP,
             workRequest
         )

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/book/detail/Navigation.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/book/detail/Navigation.kt
@@ -65,6 +65,26 @@ fun NavGraphBuilder.bookDetailDestination() {
         LaunchedEffect(bookId) {
             viewModel.init(bookId)
         }
+        val cacheSnackbarState = viewModel.cacheSnackbarState
+        LaunchedEffect(cacheSnackbarState) {
+            val state = cacheSnackbarState ?: return@LaunchedEffect
+            val message = when(state){
+                WorkInfo.State.RUNNING -> context.getString(R.string.cache_book_running)
+                WorkInfo.State.SUCCEEDED -> context.getString(R.string.cache_book_finished)
+                WorkInfo.State.FAILED,
+                WorkInfo.State.CANCELLED -> context.getString(R.string.cache_book_error)
+                WorkInfo.State.ENQUEUED,
+                WorkInfo.State.BLOCKED -> context.getString(
+                    R.string.cache_book_started,
+                    viewModel.uiState.bookInformation.title.ifBlank { bookId }
+                )
+            }
+            showSnackbar(
+                coroutineScope = coroutineScope,
+                hostState = snackbarHostState,
+                message = message
+            )
+        }
         DetailScreen(
             uiState = viewModel.uiState,
             onClickExportToEpub = { settings ->
@@ -93,45 +113,7 @@ fun NavGraphBuilder.bookDetailDestination() {
                 }
             },
             cacheBook = { bookId ->
-                coroutineScope.launch {
-                    viewModel.cacheBook(bookId).collect {
-                        if (it == null) {
-                            showSnackbar(
-                                coroutineScope = coroutineScope,
-                                hostState = snackbarHostState,
-                                message = context.getString(
-                                    R.string.cache_book_started,
-                                    viewModel.uiState.bookInformation.title
-                                )
-                            ) { }
-                            return@collect
-                        }
-                        when (it.state) {
-                            WorkInfo.State.SUCCEEDED -> {
-                                showSnackbar(
-                                    coroutineScope = coroutineScope,
-                                    hostState = snackbarHostState,
-                                    message = context.getString(R.string.cache_book_finished)
-                                ) { }
-                            }
-                            WorkInfo.State.FAILED -> {
-                                showSnackbar(
-                                    coroutineScope = coroutineScope,
-                                    hostState = snackbarHostState,
-                                    message = context.getString(R.string.cache_book_error)
-                                ) { }
-                            }
-                            WorkInfo.State.RUNNING -> {
-                                showSnackbar(
-                                    coroutineScope = coroutineScope,
-                                    hostState = snackbarHostState,
-                                    message = context.getString(R.string.cache_book_running)
-                                ) { }
-                            }
-                            else -> {}
-                        }
-                    }
-                }
+                viewModel.cacheBook(bookId)
             },
             requestAddBookToBookshelf = navController::navigateToAddBookToBookshelfDialog,
             onClickTag = viewModel::onClickTag,


### PR DESCRIPTION
以下 PR 由 AI 生成：
## 变更说明

修复 #321：缓存任务在“退出详情页再进入”场景下状态展示不一致，以及导出任务与缓存任务状态提示互相干扰的问题。

## 问题原因

1. `bookId` 相关状态读取存在协程时序问题。详情页重建早期，`downloadItem` 过滤可能依赖了尚未稳定的书籍上下文，导致进度状态偶发为空或错位。
2. 详情页初始化时未完整恢复/检测 WorkManager 当前状态，导致重进页面后 Snackbar 触发链断开，出现该显示却不显示的问题。
3. WorkManager unique work 名仅用 `bookId`，未区分任务类型，导致 `cache` 与 `export` 共享同一队列语义，状态与提示（Snackbar）发生冲突。

## 本次修改

1. 详情页侧改为以当前页面 `bookId` 直接关联缓存进度与状态监听，避免因初始化时序导致的错配。
2. 新增/前置缓存任务状态监控初始化：进入详情页即恢复监听 WorkManager 状态，并统一通过状态变更触发 Snackbar。
3. 拆分 unique work 命名空间：
   - 缓存：`cache:<bookId>`
   - 导出：`export:<bookId>`
   从调度层彻底隔离两类任务，避免互相覆盖或串扰。

## 验证

1. 缓存中退出详情页再进入，进度与状态可继续正确展示。
2. 缓存完成可正常弹出完成提示，不再丢失。
3. 导出 EPUB 与缓存并行时，Snackbar 提示不再互相冲突。
