### PR TITLE
fix: 修复长按选中文本后音量键翻页失效 (#454)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,7 +24,7 @@ android {
         minSdk = 24
         targetSdk = 37
         // 版本号为x.y.z则versionCode为x*1000000+y*10000+z*1000+debug版本号(开发需要时迭代, 三位数)
-        versionCode = 1_02_01_006
+        versionCode = 1_02_01_007
         versionName = "1.2.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/book/reader/content/flip/FlipPageContentComponent.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/book/reader/content/flip/FlipPageContentComponent.kt
@@ -235,6 +235,9 @@ private fun SimpleFlipPageTextComponent(
                         } else if (event.key == Key.VolumeUp || event.key == Key.VolumeDown) {
                             when (event.type) {
                                 KeyEventType.KeyDown -> {
+                                    // 长按选中文本会把焦点转移到 SelectionContainer，导致后续音量键事件
+                                    // 不再被此处拦截而弹出系统音量条。每次按键时主动抢回焦点以保证持续翻页。
+                                    focusRequester.requestFocus()
                                     if (event.nativeKeyEvent.repeatCount == 0) {
                                         if (event.key == Key.VolumeUp) lastPage(uiState.pagerState)
                                         else nextPage(uiState.pagerState)


### PR DESCRIPTION
﻿## 问题
Fixes #454

在阅读界面长按选中文本后，音量键翻页从第二次按键起失效，转而弹出系统音量条。

## 原因
音量键翻页依赖翻页组件持有焦点（`focusable` + `onKeyEvent` 拦截并消费按键）。
长按选中文本会把焦点转移到正文的 `SelectionContainer`，翻页组件失焦后
`onKeyEvent` 收不到音量键事件，事件落到系统默认处理，弹出音量条。

## 修复
在音量键 `KeyDown` 处理入口调用 `focusRequester.requestFocus()`，
每次按键都把焦点抢回翻页组件，保证选中文本后仍能持续稳定翻页。

## 测试
- 本地构建通过（compileDebugKotlin / assembleDebug）
- 真机按 #454 复现步骤验证：长按选中文本后连续按音量键可持续翻页，不再弹出音量条
- 回归：未选中文本时的连续翻页、长按连续翻页均正常
