### PR TITLE
fix: ColorPickerDialog 描述文字未区分文字/背景颜色

### DIFF
--- a/api/src/main/kotlin/io/nightfish/lightnovelreader/api/Route.kt
+++ b/api/src/main/kotlin/io/nightfish/lightnovelreader/api/Route.kt
@@ -1,6 +1,7 @@
 package io.nightfish.lightnovelreader.api
 
 import androidx.annotation.Keep
+import androidx.annotation.StringRes
 import kotlinx.serialization.Serializable
 
 /**
@@ -205,15 +206,33 @@ object Route {
         data object Reader
 
         /**
+         * 颜色选择器调色盘用途
+         */
+        interface ColorPickerTarget {
+            @get:StringRes
+            val descriptionResId: Int
+        }
+
+        /**
+         * 颜色选择器调色盘用途类型（用于路由序列化）
+         */
+        enum class ColorPickerTargetType {
+            TEXT,
+            BACKGROUND,
+        }
+
+        /**
          * 颜色选择器对话框路由
          *
          * @param colorUserDataPath 颜色用户数据的路径字符串
          * @param colors 可选颜色的ARGB值列表
+         * @param target 调色盘用途类型
          */
         @Serializable
         data class ColorPickerDialog(
             val colorUserDataPath: String,
-            val colors: LongArray
+            val colors: LongArray,
+            val target: ColorPickerTargetType = ColorPickerTargetType.BACKGROUND,
         ) {
             /**
              * 判断两个[ColorPickerDialog]是否相等
@@ -229,18 +248,20 @@ object Route {
 
                 if (colorUserDataPath != other.colorUserDataPath) return false
                 if (!colors.contentEquals(other.colors)) return false
+                if (target != other.target) return false
 
                 return true
             }
 
             /**
-             * 基于[colorUserDataPath]和[colors]计算哈希值
+             * 基于[colorUserDataPath]、[colors]和[target]计算哈希值
              *
              * @return 哈希值
              */
             override fun hashCode(): Int {
                 var result = colorUserDataPath.hashCode()
                 result = 31 * result + colors.contentHashCode()
+                result = 31 * result + target.hashCode()
                 return result
             }
         }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,7 +25,7 @@ android {
         minSdk = 24
         targetSdk = 37
         // 版本号为x.y.z则versionCode为x*1000000+y*10000+z*1000+debug版本号(开发需要时迭代, 三位数)
-        versionCode = 1_03_00_001
+        versionCode = 1_03_00_002
         versionName = "1.3.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/book/reader/AppColorPickerTarget.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/book/reader/AppColorPickerTarget.kt
@@ -1,0 +1,18 @@
+package indi.dmzz_yyhyy.lightnovelreader.ui.book.reader
+
+import androidx.annotation.StringRes
+import io.nightfish.lightnovelreader.api.Route
+import indi.dmzz_yyhyy.lightnovelreader.R
+
+sealed class AppColorPickerTarget(
+    @get:StringRes
+    override val descriptionResId: Int
+) : Route.Book.ColorPickerTarget {
+    data object Text : AppColorPickerTarget(R.string.dialog_color_picker_text_desc)
+    data object Background : AppColorPickerTarget(R.string.dialog_color_picker_background_desc)
+}
+
+fun Route.Book.ColorPickerTargetType.toAppTarget(): AppColorPickerTarget = when (this) {
+    Route.Book.ColorPickerTargetType.TEXT -> AppColorPickerTarget.Text
+    Route.Book.ColorPickerTargetType.BACKGROUND -> AppColorPickerTarget.Background
+}

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/book/reader/Navigation.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/book/reader/Navigation.kt
@@ -92,14 +92,15 @@ private fun NavGraphBuilder.colorPickerDialog() {
                 navController.popBackStack()
             },
             selectedColor = selectedColor ?: Color.Unspecified,
-            colors = route.colors.map { Color(if (it < 0) return@map Color.Unspecified else it) }
+            colors = route.colors.map { Color(if (it < 0) return@map Color.Unspecified else it) },
+            description = stringResource(route.target.toAppTarget().descriptionResId)
         )
     }
 }
 
-fun NavController.navigateToColorPickerDialog(colorUserDataPath: String, colors: List<Long>) {
+fun NavController.navigateToColorPickerDialog(colorUserDataPath: String, colors: List<Long>, target: Route.Book.ColorPickerTargetType = Route.Book.ColorPickerTargetType.BACKGROUND) {
     if (!this.isResumed()) return
-    navigate(Route.Book.ColorPickerDialog(colorUserDataPath, colors.toLongArray()))
+    navigate(Route.Book.ColorPickerDialog(colorUserDataPath, colors.toLongArray(), target))
 }
 @SuppressLint("LocalContextGetResourceValueCall")
 private fun NavGraphBuilder.imageViewerDialog() {

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/components/Dialog.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/components/Dialog.kt
@@ -723,6 +723,7 @@ fun ColorPickerDialog(
     onConfirmation: (Color) -> Unit,
     selectedColor: Color,
     colors: List<Color>,
+    description: String = stringResource(R.string.dialog_color_picker_background_desc),
 ) {
     var currentColor by remember {
         mutableStateOf(selectedColor)
@@ -731,7 +732,7 @@ fun ColorPickerDialog(
     BaseDialog (
         icon = painterResource(R.drawable.palette_24px),
         title = stringResource(R.string.dialog_color_picker),
-        description = stringResource(R.string.dialog_color_picker_desc),
+        description = description,
         onDismissRequest = onDismissRequest,
         onConfirmation = { onConfirmation(currentColor) },
         dismissText = stringResource(R.string.cancel),

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/settings/theme/ThemeNavigation.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/settings/theme/ThemeNavigation.kt
@@ -24,14 +24,16 @@ fun NavGraphBuilder.settingsThemeDestination() {
                 navController.navigateToColorPickerDialog(
                     if (isDark) UserDataPath.Reader.TextDarkColor.path
                     else UserDataPath.Reader.TextColor.path,
-                    listOf(-1, 0xFF1D1B20, 0xFFE6E0E9)
+                    listOf(-1, 0xFF1D1B20, 0xFFE6E0E9),
+                    target = Route.Book.ColorPickerTargetType.TEXT,
                 )
             },
             onClickChangeBackgroundColor = {
                 navController.navigateToColorPickerDialog(
                     if (isDark) UserDataPath.Reader.BackgroundDarkColor.path
                     else UserDataPath.Reader.BackgroundColor.path,
-                    listOf(-1, 0x38E8CCA5, 0x38FF8080, 0x38d3b17d,0x3834C759, 0x3832ADE6, 0x38007AFF, 0x385856D6, 0x38AF52DE)
+                    listOf(-1, 0x38E8CCA5, 0x38FF8080, 0x38d3b17d,0x3834C759, 0x3832ADE6, 0x38007AFF, 0x385856D6, 0x38AF52DE),
+                    target = Route.Book.ColorPickerTargetType.BACKGROUND,
                 )
             },
         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -491,7 +491,8 @@
     <string name="dialog_slider_custom">Enter Value</string>
     <string name="dialog_slider_custom_illegal_value">Please enter a valid number.</string>
     <string name="dialog_color_picker">Color Palette</string>
-    <string name="dialog_color_picker_desc">Select a color for the reader background.</string>
+    <string name="dialog_color_picker_background_desc">Select a color for the reader background.</string>
+    <string name="dialog_color_picker_text_desc">Select a color for the reader text.</string>
 
     <!-- Plugin -->
     <string name="plugin_delete_title">Delete %1$s</string>


### PR DESCRIPTION
ColorPickerDialog 的 description 固定为背景色描述，导致设置
文字颜色时调色盘描述仍显示"选择一个颜色用于阅读器背景。"

- ColorPickerDialog 新增 description 参数，允许调用方自定义描述
- Route.Book 新增 ColorPickerTarget 枚举（TEXT / BACKGROUND）
- 调用方根据用途传入对应 target，dialog 据此选择描述文字
- 补充 en / zh-CN / zh-TW / ru 四个 locale 的文字颜色描述

Fix #462 