### PR TITLE
fix: 修复未设置自定义背景时翻页模式误报「加载失败」(#444)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,7 +25,7 @@ android {
         minSdk = 24
         targetSdk = 37
         // 版本号为x.y.z则versionCode为x*1000000+y*10000+z*1000+debug版本号(开发需要时迭代, 三位数)
-        versionCode = 1_03_00_000
+        versionCode = 1_03_00_001
         versionName = "1.3.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/book/reader/content/flip/FlipPageContentComponent.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/book/reader/content/flip/FlipPageContentComponent.kt
@@ -138,12 +138,14 @@ private fun SimpleFlipPageTextComponent(
     val focusRequester = remember { FocusRequester() }
     val snackbarHostState = LocalSnackbarHost.current
 
-    val painter = rememberReaderBackgroundPainter(settingState)
-    val bgPainter = remember(settingState.enableBackgroundImage, settingState.backgroundImageDisplayMode) {
-        if (settingState.enableBackgroundImage &&
-            settingState.backgroundImageDisplayMode == MenuOptions.ReaderBgImageDisplayModeOptions.Loop
-        ) painter else null
-    }
+    // 仅在启用背景图时才创建 painter：rememberReaderBackgroundPainter 会发起图片加载副作用，
+    // 无条件调用会导致未开启背景时也去联网加载内置牛皮纸，失败时误报「加载失败」(见 issue #444)。
+    val bgPainter = if (
+        settingState.enableBackgroundImage &&
+        settingState.backgroundImageDisplayMode == MenuOptions.ReaderBgImageDisplayModeOptions.Loop
+    ) {
+        rememberReaderBackgroundPainter(settingState)
+    } else null
 
     val windowInfo = LocalWindowInfo.current
     val screenWidthPx = windowInfo.containerSize.width.toFloat()

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/utils/ReaderCustomUtils.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/utils/ReaderCustomUtils.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.graphics.isUnspecified
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -22,6 +23,7 @@ import coil3.compose.rememberAsyncImagePainter
 import coil3.request.CachePolicy
 import coil3.request.ImageRequest
 import coil3.size.Scale
+import indi.dmzz_yyhyy.lightnovelreader.R
 import indi.dmzz_yyhyy.lightnovelreader.ui.LocalAppTheme
 import indi.dmzz_yyhyy.lightnovelreader.ui.book.reader.SettingState
 import io.nightfish.lightnovelreader.api.userdata.UriUserData
@@ -56,11 +58,12 @@ fun rememberReaderFontFamily(
     val fontFamily = remember(uri) { loadReaderFontFamilySafe(uri) }
 
     val snackbarHostState = LocalSnackbarHost.current
+    val message = stringResource(R.string.reader_custom_font_load_failed)
     if (fontFamily == null && uri != Uri.EMPTY) {
         LaunchedEffect(uri) {
             withContext(Dispatchers.IO) { fontFamilyUriUserData.set(Uri.EMPTY) }
             snackbarScope.launch {
-                snackbarHostState.showSnackbar("自定义字体加载失败，已恢复为默认。")
+                snackbarHostState.showSnackbar(message)
             }
         }
     }
@@ -69,15 +72,12 @@ fun rememberReaderFontFamily(
 }
 
 @Composable
-private fun rememberPaperPainter(
-    snackbarScope: CoroutineScope,
-): Painter {
+private fun rememberPaperPainter(): Painter {
     val context = LocalContext.current
     val theme = LocalAppTheme.current
     val fallback = remember(theme.isDark, theme.colorScheme.background) {
         ColorPainter(theme.colorScheme.background)
     }
-    val snackbarHostState = LocalSnackbarHost.current
 
     val request = remember {
         ImageRequest.Builder(context)
@@ -92,13 +92,32 @@ private fun rememberPaperPainter(
             .build()
     }
 
-    val painter = rememberAsyncImagePainter(
+    // 内置牛皮纸是联网资源，加载失败时静默回退到背景色即可，不弹提示打扰用户。
+    return rememberAsyncImagePainter(
         model = request,
         placeholder = fallback,
         error = fallback
     )
+}
 
-    var errorNotified by remember { mutableStateOf(false) }
+@Composable
+private fun rememberCustomBackgroundPainter(
+    uri: Uri,
+    snackbarScope: CoroutineScope,
+): Painter {
+    val theme = LocalAppTheme.current
+    val fallback = remember(theme.isDark, theme.colorScheme.background) {
+        ColorPainter(theme.colorScheme.background)
+    }
+    val snackbarHostState = LocalSnackbarHost.current
+    val message = stringResource(R.string.reader_custom_background_load_failed)
+
+    val painter = rememberAsyncImagePainter(
+        model = uri,
+        error = fallback
+    )
+
+    var errorNotified by remember(uri) { mutableStateOf(false) }
 
     LaunchedEffect(painter) {
         painter.state.collect { state ->
@@ -107,7 +126,7 @@ private fun rememberPaperPainter(
                     if (!errorNotified) {
                         errorNotified = true
                         snackbarScope.launch {
-                            snackbarHostState.showSnackbar("自定义背景加载失败，已恢复为默认。")
+                            snackbarHostState.showSnackbar(message)
                         }
                     }
                 }
@@ -138,12 +157,10 @@ fun rememberReaderBackgroundPainter(
     }
 
     if (backgroundUri == Uri.EMPTY || backgroundUri.toString().isBlank()) {
-        return rememberPaperPainter(snackbarScope)
+        return rememberPaperPainter()
     }
 
-    return rememberAsyncImagePainter(
-        model = backgroundUri
-    )
+    return rememberCustomBackgroundPainter(backgroundUri, snackbarScope)
 }
 
 @Composable

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,6 +91,8 @@
     <string name="offline_desc">Please check the availability of the source website and your proxy settings.</string>
     <string name="saved_to_pictures_dir">Saved to Pictures/LightNovelReader/%s</string>
     <string name="save_failed">Save failed</string>
+    <string name="reader_custom_font_load_failed">Failed to load custom font, reverted to default.</string>
+    <string name="reader_custom_background_load_failed">Failed to load custom background, reverted to default.</string>
     <string name="reader_first_page">You are on the first page</string>
     <string name="reader_reached_top">You have reached the top</string>
     <string name="reader_last_page">You are on the last page</string>


### PR DESCRIPTION
## 关联 issue
Closes #444

## 问题
翻页模式下每次进入阅读都会弹出「自定义背景加载失败，已恢复为默认」，但用户并未设置任何自定义背景；关闭翻页模式则不会出现。

## 根因
- 那条提示实际来自 `rememberPaperPainter`，加载的是**内置牛皮纸**背景（联网资源 `KRAFT_PAPER_URL`），并非用户自定义背景，文案本身就有误导。
- 未设置自定义背景时，`rememberReaderBackgroundPainter` 会回退到该联网牛皮纸；网络不可达即加载失败。
- 翻页模式 `FlipPageContentComponent` **无条件**调用 `rememberReaderBackgroundPainter`（该组合函数内部会发起图片加载副作用），即使未开启背景图也会触发联网加载并弹提示；滚动模式仅在开启背景图时才调用，故无此问题。

## 改动
- **FlipPageContentComponent**：仅在开启背景图时才调用 `rememberReaderBackgroundPainter`，与滚动模式行为一致。
- **ReaderCustomUtils**：
  - 内置牛皮纸加载失败改为**静默回退**到背景色（本就有 `ColorPainter` 兜底），不再弹提示。
  - 新增 `rememberCustomBackgroundPainter`，**仅对用户自定义背景**加载失败弹提示，使提示名副其实。
- 将两处硬编码中文提示改为字符串资源 `reader_custom_font_load_failed` / `reader_custom_background_load_failed`（英文源，翻译由 Crowdin 回填）。
- 递增 `versionCode` 至 `1_03_00_001`。

## 备注
自定义背景加载失败时选择「视觉回退默认背景色 + 提示」但**不自动清除**已设置的 URI，以避免瞬时失败误删用户设置。