### PR TITLE
fix: 修复自定义字体导入后不生效 (#486)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,7 +25,7 @@ android {
         minSdk = 24
         targetSdk = 37
         // 版本号为x.y.z则versionCode为x*1000000+y*10000+z*1000+debug版本号(开发需要时迭代, 三位数)
-        versionCode = 1_03_00_006
+        versionCode = 1_03_00_007
         versionName = "1.3.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/settings/theme/ThemeScreen.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/ui/home/settings/theme/ThemeScreen.kt
@@ -1,6 +1,7 @@
 package indi.dmzz_yyhyy.lightnovelreader.ui.home.settings.theme
 
 import android.content.Context
+import android.graphics.Typeface
 import android.net.Uri
 import android.os.Build
 import android.util.Log
@@ -53,11 +54,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.Font
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -383,7 +380,6 @@ fun ReaderThemeSettingsList(
 @Composable
 fun ReaderTextSettings(settingState: SettingState, context: Context, onClickChangeTextColor: () -> Unit) {
     val coroutineScope = rememberCoroutineScope()
-    val textMeasurer = rememberTextMeasurer()
     val onSecondaryContainer = colorScheme.onSecondaryContainer
     val background = colorScheme.background
     val currentColor = readerTextColor(settingState)
@@ -433,21 +429,8 @@ fun ReaderTextSettings(settingState: SettingState, context: Context, onClickChan
                     return@launch
                 }
 
-                try {
-                    textMeasurer.measure(
-                        text = "",
-                        style = TextStyle(fontFamily = FontFamily(Font(fontFile)))
-                    )
-                    settingState.fontFamilyUriUserData.set(fontFile.toUri())
-                } catch (_: Exception) {
-                    withContext(Dispatchers.Main) {
-                        Toast.makeText(
-                            context,
-                            context.getString(R.string.font_file_error),
-                            Toast.LENGTH_SHORT
-                        ).show()
-                    }
-                }
+                settingState.fontFamilyUriUserData.set(fontFile.toUri())
+                cleanUpImportedFonts(context, keep = fontFile)
             }
         }
 
@@ -537,22 +520,85 @@ fun ReaderTextSettings(settingState: SettingState, context: Context, onClickChan
     }
 }
 
+private const val FONT_LOG_TAG = "ReaderTextFont"
+private const val FONT_FILE_PREFIX = "readerTextFont_"
+/** 1.2.1 及更早版本使用的固定文件名，仅用于清理历史遗留文件 */
+private const val LEGACY_FONT_FILE_NAME = "readerTextFont"
+
+/**
+ * 把用户选中的字体复制到应用私有目录。
+ *
+ * 文件名带时间戳，保证每次导入得到**不同**的 Uri。旧实现固定写入 `readerTextFont`，
+ * Uri 永远不变，导致 [rememberReaderFontFamily] 里的 `remember(uri)` 与 Compose 的字体
+ * 解析缓存全部命中旧值，换字体时表现为「毫无反应」。
+ *
+ * 复制先落到 `.tmp`，通过校验后才改名就位，因此导入失败不会破坏当前正在使用的字体。
+ *
+ * @return 导入成功的字体文件；来源无法读取、内容为空或不是有效字体时返回 null
+ */
 private suspend fun saveFontToLocal(context: Context, uri: Uri): File? = withContext(Dispatchers.IO) {
-    val fontFile = context.filesDir.resolve("readerTextFont").apply {
-        if (exists()) delete()
-        createNewFile()
-    }
+    val target = File(context.filesDir, "$FONT_FILE_PREFIX${System.currentTimeMillis()}")
+    val temp = File(context.filesDir, "${target.name}.tmp")
     try {
-        context.contentResolver.openFileDescriptor(uri, "r")?.use { fd ->
-            FileInputStream(fd.fileDescriptor).use { input ->
-                fontFile.outputStream().use { output -> input.copyTo(output) }
-            }
+        // 部分数据源（云盘、"最近使用"等）不支持 openFileDescriptor，openInputStream 兼容性更好。
+        // 旧实现用 `?.use {}` 吞掉了 null，把 0 字节空文件当成导入成功。
+        val inputStream = context.contentResolver.openInputStream(uri)
+        if (inputStream == null) {
+            Log.e(FONT_LOG_TAG, "Cannot open input stream for $uri")
+            return@withContext null
         }
-        fontFile
+        val copied = inputStream.use { input ->
+            temp.outputStream().use { output -> input.copyTo(output) }
+        }
+        if (copied <= 0L) {
+            Log.e(FONT_LOG_TAG, "Imported font is empty")
+            return@withContext null
+        }
+        if (!isValidFontFile(temp)) {
+            Log.e(FONT_LOG_TAG, "Selected file is not a valid font")
+            return@withContext null
+        }
+        if (!temp.renameTo(target)) {
+            Log.e(FONT_LOG_TAG, "Failed to move imported font into place")
+            return@withContext null
+        }
+        target
     } catch (e: Exception) {
-        Log.e("ReaderTextFont", "Failed to import font", e)
+        Log.e(FONT_LOG_TAG, "Failed to import font", e)
         null
+    } finally {
+        // 成功改名后 temp 已不存在，这里的 delete 只负责清理失败残留
+        temp.delete()
     }
+}
+
+/**
+ * 用 Android 原生字体解析验证文件是否真的是字体。
+ *
+ * 相比用 `TextMeasurer` 测量空字符串，这里能真正解析文件内容；且是纯 Android API，
+ * 可以安全地在 IO 线程调用。
+ */
+private fun isValidFontFile(file: File): Boolean = try {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        Typeface.Builder(file).build() != null
+    } else {
+        // API 24/25 没有 Typeface.Builder，只能依赖 createFromFile 解析失败时抛异常
+        Typeface.createFromFile(file) != null
+    }
+} catch (e: Exception) {
+    Log.e(FONT_LOG_TAG, "Font validation failed", e)
+    false
+}
+
+/** 删除除 [keep] 之外的历史字体文件，避免每次导入都在私有目录里留下一份副本 */
+private fun cleanUpImportedFonts(context: Context, keep: File) {
+    context.filesDir
+        .listFiles { file ->
+            file.isFile &&
+                    (file.name == LEGACY_FONT_FILE_NAME || file.name.startsWith(FONT_FILE_PREFIX)) &&
+                    file.name != keep.name
+        }
+        ?.forEach { it.delete() }
 }
 
 @Composable

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/utils/ReaderCustomUtils.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/utils/ReaderCustomUtils.kt
@@ -41,7 +41,9 @@ fun loadReaderFontFamilySafe(uri: Uri): FontFamily? {
     return try {
         if (uri == Uri.EMPTY) return null
         val fontFile = File(uri.path ?: return null)
-        if (!fontFile.exists()) throw FileNotFoundException()
+        // 0 字节文件同样能通过 exists()，必须额外判长度，
+        // 否则导入中断留下的空文件会被当作有效字体，表现为「设置了但没变化」。
+        if (!fontFile.exists() || fontFile.length() == 0L) throw FileNotFoundException()
         FontFamily(Font(fontFile))
     } catch (e: Exception) {
         Log.e("FontLoad", "Failed to load custom font", e)


### PR DESCRIPTION
## 问题

修复 #486：导入自定义字体，选择文件后无反应。

## 原因

导入的字体固定写入 `filesDir/readerTextFont`，因此存入用户数据的 Uri 恒为 `file:///data/user/0/<pkg>/files/readerTextFont`，**更换字体时这个字符串不变**。于是多层缓存全部命中旧值：

1. `UriUserData.set()` 写入 Room 的值与旧值相同；
2. `ReaderCustomUtils.kt` 中 `remember(uri) { loadReaderFontFamilySafe(uri) }` 的 key 未变，字体不会重新加载；
3. 即使重新加载，`FontFamily(Font(file))` 的解析结果按文件路径缓存于 Compose 的 `FontFamilyResolver`，仍返回旧 Typeface。

表现为「第一次导入正常，之后换字体毫无反应」，且杀进程重启后新字体才生效。

另有一条独立路径也会导致「无反应」：`saveFontToLocal` 中

```kotlin
context.contentResolver.openFileDescriptor(uri, "r")?.use { ... }
fontFile   // 无条件返回
```

部分数据源（云盘、「最近使用」等）不支持 `openFileDescriptor`，返回 null 时 `?.use {}` 静默跳过复制，但函数仍返回那个刚 `createNewFile()` 出来的 **0 字节文件**并被视作成功。该空文件又能通过读取端的 `fontFile.exists()` 检查，最终存下一个指向空文件的 Uri，既不生效也无任何提示。

## 改动

- 导入文件名改为 `readerTextFont_<时间戳>`，保证每次导入产生不同的 Uri，使上述缓存自然失效；
- 用 `openInputStream` 替代 `openFileDescriptor`，并显式处理返回 null 与复制字节数为 0 的情况；
- 复制先写入 `.tmp`，校验通过后再 `renameTo` 就位，导入失败不再破坏当前正在使用的字体；
- 校验改用 `Typeface` 解析实际文件内容，替代原先测量空字符串的无效校验，同时避免在 `Dispatchers.IO` 上使用非线程安全的 `TextMeasurer`（`Typeface.Builder` 需 API 26，已按 minSdk 24 做版本分支）；
- `loadReaderFontFamilySafe` 增加 0 字节文件判断；
- 导入成功后清理历史字体文件（含 1.2.1 及更早版本遗留的固定名文件）。

未按 MIME 过滤选择器：Android 上大量文件管理器将 `.ttf` 报为 `application/octet-stream` 而非 `font/*`，加过滤会导致用户在选择器中看不到字体文件。改为保留 `*/*` 并在解析失败时给出明确 Toast。

## 测试

- `:app:compileDebugKotlin` 通过；
- `:app:lintDebug` 在改动文件上无新增 error（仅 `LogNotTimber` warning，与既有代码一致）；
- `versionCode` 递增至 `1_03_00_007`。

尚未在真机验证，烦请协助测试「导入字体 A → 再导入字体 B」这一场景。
