### PR TITLE
fix: 修复 wenku8 页面部分标点解码为乱码 (#485)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,7 +25,7 @@ android {
         minSdk = 24
         targetSdk = 37
         // 版本号为x.y.z则versionCode为x*1000000+y*10000+z*1000+debug版本号(开发需要时迭代, 三位数)
-        versionCode = 1_03_00_006
+        versionCode = 1_03_00_007
         versionName = "1.3.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,7 +25,7 @@ android {
         minSdk = 24
         targetSdk = 37
         // 版本号为x.y.z则versionCode为x*1000000+y*10000+z*1000+debug版本号(开发需要时迭代, 三位数)
-        versionCode = 1_03_00_007
+        versionCode = 1_03_00_008
         versionName = "1.3.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/defaultplugin/wenku8/Wenku8Api.kt
+++ b/app/src/main/kotlin/indi/dmzz_yyhyy/lightnovelreader/defaultplugin/wenku8/Wenku8Api.kt
@@ -30,7 +30,7 @@ import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.request.cookie
 import io.ktor.client.request.get
-import io.ktor.client.statement.bodyAsText
+import io.ktor.client.statement.bodyAsBytes
 import io.ktor.http.Cookie
 import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
@@ -73,6 +73,9 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import kotlin.time.Duration.Companion.milliseconds
 
+
+/** wenku8 页面使用的字符集。声明为 gbk，实际输出 GB18030，详见 [Wenku8Api.getWithWenku8Cookie] */
+private val WENKU8_CHARSET: Charset = Charset.forName("GB18030")
 
 @WebDataSource(
     "Wenku8",
@@ -336,8 +339,13 @@ class Wenku8Api : WebBookDataSource {
     suspend fun getWithWenku8Cookie(url: String): Result<Document, Throwable> = withContext(Dispatchers.IO) {
         requestLimiter.withPermit {
             runCatching {
-                 val res = ktorClient.get(url)
-                     .bodyAsText(Charset.forName("GBK"))
+                // wenku8 实际以 GB18030 输出：• ・ 〜 等字符不在 GBK 字符集内，
+                // 会以 GB18030 独有的 4 字节序列传输，按 GBK 解码后碎成乱码（issue #485）。
+                // GB18030 是 GBK 的严格超集，原本能正确解出的内容不受影响。
+                //
+                // 这里读原始字节自行解码，而不是把字符集交给 bodyAsText：
+                // 后者的参数只是 fallback，响应头声明了 charset 时并不生效。
+                val res = String(ktorClient.get(url).bodyAsBytes(), WENKU8_CHARSET)
                 Jsoup.parse(res).outputSettings(
                     Document.OutputSettings()
                         .prettyPrint(false)


### PR DESCRIPTION
## 问题

修复 #485：搜索结果列表中部分标点显示为乱码，进入详情页正常，收藏后的列表也正常。

## 原因

`Wenku8Api.getWithWenku8Cookie` 固定按 GBK 解码页面：

```kotlin
val res = ktorClient.get(url).bodyAsText(Charset.forName("GBK"))
```

但 wenku8 实际以 **GB18030** 输出。二者对汉字（双字节）映射完全一致，因此中文正常；而 `•`(U+2022)、`・`(U+30FB)、`〜`(U+301C) 等字符**不在 GBK 字符集内**，只能以 GB18030 独有的 4 字节序列传输，按 GBK 解码后碎为 `U+FFFD` + ASCII 数字。这正是「只有部分标点乱码」的成因。

JDK 实测：

| 字符 | GBK 可编码 | GB18030 字节 | 按 GBK 解码结果 |
|---|---|---|---|
| `•` U+2022 | ✗ | `81 36 A6 31` | `U+FFFD 6 U+FFFD 1` |
| `・` U+30FB | ✗ | `81 39 A7 39` | `U+FFFD 9 U+FFFD 9` |
| `〜` U+301C | ✗ | `81 39 A4 31` | `U+FFFD 9 U+FFFD 1` |
| `·` U+00B7 | ✓ | `A1 A4` | `·` 正常 |
| `～` U+FF5E | ✓ | `A1 AB` | `～` 正常 |
| `中` U+4E2D | ✓ | `D6 D0` | `中` 正常 |

用 jsoup 1.22.1 端到端复现（构造含 `•` 的搜索卡片 HTML，按 GB18030 编码为字节后分别解码再取 `attr("title")`）：GBK 路径得到 `鲁迪乌斯?6?1格雷拉特`，GB18030 路径与原文完全相等。

## 改动

读取原始字节后按 GB18030 解码：

```kotlin
val res = String(ktorClient.get(url).bodyAsBytes(), WENKU8_CHARSET)
```

不再把字符集交给 `bodyAsText`——其参数只是 **fallback**，响应头声明了 charset 时并不生效，无法保证行为一致。

## 兼容性

GB18030 是 GBK 的严格超集。穷举全部合法 GBK 单/双字节序列比对两种解码结果：24068 个序列中仅 100 个不同，且全部是 GBK 映射到 Unicode 私有区、GB18030 映射到正确码位的情况，例如：

| 字节 | GBK | GB18030 |
|---|---|---|
| `A6D9`–`A6F3` | `U+E78D`…（私有区，渲染为方框） | `U+FE10`… 竖排标点 |
| `A8BC` | `U+E7C7`（私有区） | `U+1E3F` ḿ |
| `A892` | `U+2641` ♁ | `U+2295` ⊕ |

即改动只会修复更多显示问题，不存在回归。

## 待确认

本 PR 解释了乱码本身，但未能完全解释「为何详情页不受影响」——搜索页与详情页走的是同一个 `getWithWenku8Cookie`。两种可能：一是两个 URL 的 `Content-Type` charset 声明不同，导致 Ktor 对详情页使用了响应头中的正确字符集、仅搜索页落到硬编码的 GBK；二是详情页 `<b>` 中的书名用的是 `·`(U+00B7)，而搜索卡片 `title` 属性中是 `•`(U+2022)，即站点两处字段的数据本身不同。因开发环境无法访问站点（403）未能抓包验证。无论何种情况，本改动均可覆盖。

## 相关（本 PR 未处理）

`Wenku8WebsiteDataSource.kt` 等 3 处使用 `URLEncoder.encode(keyword, "gb2312")` 编码搜索关键词，含假名或 `•` 的关键词会被编码为 `%3F` 导致搜索失效。属搜索输入侧问题，且需确认服务端对 GB18030 编码查询串的接受情况，故未在此一并改动。

## 测试

- `:app:compileDebugKotlin` 通过；
- 编码行为经 JDK 实测验证，解析路径经 jsoup 端到端复现验证；
- `versionCode` 递增至 `1_03_00_008`（避开 #487 的 `007`）。

尚未在真机验证，烦请协助确认搜索「无职转生」时蛇足篇条目的标点显示。
